### PR TITLE
[12] Added implemented languages file

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -65,6 +65,19 @@
       settings.language = '';
     }
 
+    var indexFileUrl = settings.path + 'languages.json';
+
+    var languages = [];
+
+    $.ajax({
+      url: indexFileUrl,
+      async: false,
+      cache: false,
+      success: function (data, status) {
+          languages = data.languages;
+      }
+    });
+
     // load and parse bundle files
     var files = getFiles(settings.name);
     for (var i = 0; i < files.length; i++) {
@@ -72,11 +85,17 @@
       loadAndParseFile(settings.path + files[i] + '.properties', settings);
       // 2. with language code (eg, Messages_pt.properties)
       if (settings.language.length >= 2) {
-        loadAndParseFile(settings.path + files[i] + '_' + settings.language.substring(0, 2) + '.properties', settings);
+        var shortCode = settings.language.substring(0, 2);
+        if (languages.length > 0 && $.inArray(shortCode, languages) != -1) {
+            loadAndParseFile(settings.path + files[i] + '_' + shortCode + '.properties', settings);
+        }
       }
       // 3. with language code and country code (eg, Messages_pt_PT.properties)
       if (settings.language.length >= 5) {
-        loadAndParseFile(settings.path + files[i] + '_' + settings.language.substring(0, 5) + '.properties', settings);
+        var longCode = settings.language.substring(0, 5);
+        if (languages.length > 0 && $.inArray(longCode, languages) != -1) {
+            loadAndParseFile(settings.path + files[i] + '_' + longCode + '.properties', settings);
+        }
       }
     }
 


### PR DESCRIPTION
You can now create a file, in the same directory as your translation
files, listing the implemented languages. If you create this file the
plugin will not try and download languages not contained in the file.