### PR TITLE
Issue 16: Language detection should use navigator.languages when able

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -254,7 +254,7 @@
 
   /** Language reported by browser, normalized code */
   $.i18n.browserLang = function () {
-    return normaliseLanguageCode(navigator.language /* Mozilla */ || navigator.userLanguage /* IE */);
+    return normaliseLanguageCode(navigator.languages[0] /* Mozilla 32+ */ || navigator.language /* Mozilla */ || navigator.userLanguage /* IE */);
   };
 
 


### PR DESCRIPTION
In Chrome / Firefox 32+ the list of preferred languages is set in
the navigator.languages array, where the primary preferred language is
placed in index 0.

https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages

Added a quick fix that checks for existence of that value before
attempting to use the browser application level language setting.