### PR TITLE
Fix safari error 'undefined' is not an object (evaluating 'navigator.…

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -258,7 +258,7 @@
 
   /** Language reported by browser, normalized code */
   $.i18n.browserLang = function () {
-    return normaliseLanguageCode(navigator.languages[0] /* Mozilla 32+ */ || navigator.language /* Mozilla */ || navigator.userLanguage /* IE */);
+    return normaliseLanguageCode( navigator.language /* Mozilla */ || navigator.userLanguage /* IE */ || navigator.languages[0] /* Mozilla 32+ */);
   };
 
 


### PR DESCRIPTION
…languages[0]'), moved to last checking condition