### PR TITLE
load languages.json as json

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -119,6 +119,7 @@
         url: settings.path + 'languages.json',
         async: settings.async,
         cache: false,
+        dataType: 'json',
         success: function (data, textStatus, jqXHR) {
           languagesFileLoadedCallback(data.languages || []);
         }

--- a/jquery.i18n.properties.min.js
+++ b/jquery.i18n.properties.min.js
@@ -10,52 +10,14 @@
  *              by Keith Wood (kbwood{at}iinet.com.au) June 2007
  *
  *****************************************************************************/
-!function($){function callbackIfComplete(e){e.async&&(e.filesLoaded+=1,e.filesLoaded===e.totalFiles&&e.callback&&e.callback())}function loadAndParseFile(e,a){$.ajax({url:e,async:a.async,cache:a.cache,dataType:"text",success:function(e,r){parseData(e,a.mode),callbackIfComplete(a)},error:function(r,t,n){console.log("Failed to download or parse "+e),callbackIfComplete(a)}})}function parseData(data,mode){for(var parsed="",parameters=data.split(/\n/),regPlaceHolder=/(\{\d+})/g,regRepPlaceHolder=/\{(\d+)}/g,unicodeRE=/(\\u.{4})/gi,i=0;i<parameters.length;i++)if(parameters[i]=parameters[i].replace(/^\s\s*/,"").replace(/\s\s*$/,""),parameters[i].length>0&&"#"!=parameters[i].match("^#")){var pair=parameters[i].split("=")
-if(pair.length>0){for(var name=decodeURI(pair[0]).replace(/^\s\s*/,"").replace(/\s\s*$/,""),value=1==pair.length?"":pair[1];"\\"==value.match(/\\$/);)value=value.substring(0,value.length-1),value+=parameters[++i].replace(/\s\s*$/,"")
-for(var s=2;s<pair.length;s++)value+="="+pair[s]
-if(value=value.replace(/^\s\s*/,"").replace(/\s\s*$/,""),"map"==mode||"both"==mode){var unicodeMatches=value.match(unicodeRE)
-if(unicodeMatches)for(var u=0;u<unicodeMatches.length;u++)value=value.replace(unicodeMatches[u],unescapeUnicode(unicodeMatches[u]))
-$.i18n.map[name]=value}if("vars"==mode||"both"==mode)if(value=value.replace(/"/g,'\\"'),checkKeyNamespace(name),regPlaceHolder.test(value)){for(var parts=value.split(regPlaceHolder),first=!0,fnArgs="",usedArgs=[],p=0;p<parts.length;p++)!regPlaceHolder.test(parts[p])||0!=usedArgs.length&&-1!=usedArgs.indexOf(parts[p])||(first||(fnArgs+=","),fnArgs+=parts[p].replace(regRepPlaceHolder,"v$1"),usedArgs.push(parts[p]),first=!1)
-parsed+=name+"=function("+fnArgs+"){"
-var fnExpr='"'+value.replace(regRepPlaceHolder,'"+v$1+"')+'"'
-parsed+="return "+fnExpr+";};"}else parsed+=name+'="'+value+'";'}}eval(parsed)}function checkKeyNamespace(key){var regDot=/\./
-if(regDot.test(key))for(var fullname="",names=key.split(/\./),i=0;i<names.length;i++)i>0&&(fullname+="."),fullname+=names[i],eval("typeof "+fullname+' == "undefined"')&&eval(fullname+"={};")}function getFiles(e){return e&&e.constructor==Array?e:[e]}function unescapeUnicode(e){var a=[],r=parseInt(e.substr(2),16)
-r>=0&&r<Math.pow(2,16)&&a.push(r)
-for(var t="",n=0;n<a.length;++n)t+=String.fromCharCode(a[n])
-return t}$.i18n={},$.i18n.map={},$.i18n.properties=function(e){var a={name:"Messages",language:"",path:"",mode:"vars",cache:!1,encoding:"UTF-8",async:!1,checkAvailableLanguages:!1,callback:null}
-e=$.extend(a,e),e.language=this.normaliseLanguageCode(e.language)
-var r=function(a){e.totalFiles=0,e.filesLoaded=0
-var r=getFiles(e.name)
-if(e.async)for(var t=0,n=r.length;n>t;t++){e.totalFiles+=1
-var s=e.language.substring(0,2)
-if(0!=a.length&&-1==$.inArray(s,a)||(e.totalFiles+=1),e.language.length>=5){var l=e.language.substring(0,5)
-0!=a.length&&-1==$.inArray(l,a)||(e.totalFiles+=1)}}for(var i=0,g=r.length;g>i;i++){loadAndParseFile(e.path+r[i]+".properties",e)
-var s=e.language.substring(0,2)
-if(0!=a.length&&-1==$.inArray(s,a)||loadAndParseFile(e.path+r[i]+"_"+s+".properties",e),e.language.length>=5){var l=e.language.substring(0,5)
-0!=a.length&&-1==$.inArray(l,a)||loadAndParseFile(e.path+r[i]+"_"+l+".properties",e)}}e.callback&&!e.async&&e.callback()}
-e.checkAvailableLanguages?$.ajax({url:e.path+"languages.json",async:e.async,cache:!1,success:function(e,a,t){r(e.languages||[])}}):r([])},$.i18n.prop=function(e){var a=$.i18n.map[e]
-if(null==a)return"["+e+"]"
-var r
-2==arguments.length&&$.isArray(arguments[1])&&(r=arguments[1])
-var t
-if("string"==typeof a){for(t=0;-1!=(t=a.indexOf("\\",t));)a="t"==a.charAt(t+1)?a.substring(0,t)+"	"+a.substring(t++ +2):"r"==a.charAt(t+1)?a.substring(0,t)+"\r"+a.substring(t++ +2):"n"==a.charAt(t+1)?a.substring(0,t)+"\n"+a.substring(t++ +2):"f"==a.charAt(t+1)?a.substring(0,t)+"\f"+a.substring(t++ +2):"\\"==a.charAt(t+1)?a.substring(0,t)+"\\"+a.substring(t++ +2):a.substring(0,t)+a.substring(t+1)
-var n,s,l=[]
-for(t=0;t<a.length;)if("'"==a.charAt(t))if(t==a.length-1)a=a.substring(0,t)
-else if("'"==a.charAt(t+1))a=a.substring(0,t)+a.substring(++t)
-else{for(n=t+2;-1!=(n=a.indexOf("'",n));){if(n==a.length-1||"'"!=a.charAt(n+1)){a=a.substring(0,t)+a.substring(t+1,n)+a.substring(n+1),t=n-1
-break}a=a.substring(0,n)+a.substring(++n)}-1==n&&(a=a.substring(0,t)+a.substring(t+1))}else if("{"==a.charAt(t))if(n=a.indexOf("}",t+1),-1==n)t++
-else if(s=parseInt(a.substring(t+1,n)),!isNaN(s)&&s>=0){var i=a.substring(0,t)
-""!=i&&l.push(i),l.push(s),t=0,a=a.substring(n+1)}else t=n+1
-else t++
-""!=a&&l.push(a),a=l,$.i18n.map[e]=l}if(0==a.length)return""
-if(1==a.length&&"string"==typeof a[0])return a[0]
-var g=""
-for(t=0;t<a.length;t++)g+="string"==typeof a[t]?a[t]:r&&a[t]<r.length?r[a[t]]:!r&&a[t]+1<arguments.length?arguments[a[t]+1]:"{"+a[t]+"}"
-return g},$.i18n.normaliseLanguageCode=function(e){return(!e||e.length<2)&&(e=navigator.languages?navigator.languages[0]:navigator.language||navigator.userLanguage||"en"),e=e.toLowerCase(),e=e.replace(/-/,"_"),e.length>3&&(e=e.substring(0,3)+e.substring(3).toUpperCase()),e}
-var cbSplit
-cbSplit||(cbSplit=function(e,a,r){if("[object RegExp]"!==Object.prototype.toString.call(a))return"undefined"==typeof cbSplit._nativeSplit?e.split(a,r):cbSplit._nativeSplit.call(e,a,r)
-var t,n,s,l,i=[],g=0,c=(a.ignoreCase?"i":"")+(a.multiline?"m":"")+(a.sticky?"y":""),a=new RegExp(a.source,c+"g")
-if(e+="",cbSplit._compliantExecNpcg||(t=new RegExp("^"+a.source+"$(?!\\s)",c)),void 0===r||0>+r)r=1/0
-else if(r=Math.floor(+r),!r)return[]
-for(;(n=a.exec(e))&&(s=n.index+n[0].length,!(s>g&&(i.push(e.slice(g,n.index)),!cbSplit._compliantExecNpcg&&n.length>1&&n[0].replace(t,function(){for(var e=1;e<arguments.length-2;e++)void 0===arguments[e]&&(n[e]=void 0)}),n.length>1&&n.index<e.length&&Array.prototype.push.apply(i,n.slice(1)),l=n[0].length,g=s,i.length>=r)));)a.lastIndex===n.index&&a.lastIndex++
-return g===e.length?!l&&a.test("")||i.push(""):i.push(e.slice(g)),i.length>r?i.slice(0,r):i},cbSplit._compliantExecNpcg=void 0===/()??/.exec("")[1],cbSplit._nativeSplit=String.prototype.split),String.prototype.split=function(e,a){return cbSplit(this,e,a)}}(jQuery)
+(function(m){function u(b){b.async&&(b.filesLoaded+=1,b.filesLoaded===b.totalFiles&&b.callback&&b.callback())}function q(b,a){m.ajax({url:b,async:a.async,cache:a.cache,dataType:"text",success:function(b,c){v(b,a.mode);u(a)},error:function(e,c,d){console.log("Failed to download or parse "+b);u(a)}})}function v(b,a){for(var e="",c=b.split(/\n/),d=/(\{\d+})/g,f=/\{(\d+)}/g,h=/(\\u.{4})/ig,g=0;g<c.length;g++)if(c[g]=c[g].replace(/^\s\s*/,"").replace(/\s\s*$/,""),0<c[g].length&&"#"!=c[g].match("^#")){var k=
+c[g].split("=");if(0<k.length){for(var r=decodeURI(k[0]).replace(/^\s\s*/,"").replace(/\s\s*$/,""),l=1==k.length?"":k[1];"\\"==l.match(/\\$/);)l=l.substring(0,l.length-1),l+=c[++g].replace(/\s\s*$/,"");for(var p=2;p<k.length;p++)l+="="+k[p];l=l.replace(/^\s\s*/,"").replace(/\s\s*$/,"");if("map"==a||"both"==a){if(k=l.match(h))for(p=0;p<k.length;p++)l=l.replace(k[p],w(k[p]));m.i18n.map[r]=l}if("vars"==a||"both"==a)if(l=l.replace(/"/g,'\\"'),x(r),d.test(l)){for(var k=l.split(d),p=!0,n="",q=[],t=0;t<
+k.length;t++)!d.test(k[t])||0!=q.length&&-1!=q.indexOf(k[t])||(p||(n+=","),n+=k[t].replace(f,"v$1"),q.push(k[t]),p=!1);e+=r+"=function("+n+"){";r='"'+l.replace(f,'"+v$1+"')+'"';e+="return "+r+";};"}else e+=r+'="'+l+'";'}}eval(e)}function x(b){if(/\./.test(b)){var a="";b=b.split(/\./);for(var e=0;e<b.length;e++)0<e&&(a+="."),a+=b[e],eval("typeof "+a+' == "undefined"')&&eval(a+"={};")}}function w(b){var a=[];b=parseInt(b.substr(2),16);0<=b&&b<Math.pow(2,16)&&a.push(b);b="";for(var e=0;e<a.length;++e)b+=
+String.fromCharCode(a[e]);return b}m.i18n={};m.i18n.map={};m.i18n.properties=function(b){b=m.extend({name:"Messages",language:"",path:"",mode:"vars",cache:!1,encoding:"UTF-8",async:!1,checkAvailableLanguages:!1,callback:null},b);b.language=this.normaliseLanguageCode(b.language);var a=function(a){b.totalFiles=0;b.filesLoaded=0;var c;c=(c=b.name)&&c.constructor==Array?c:[c];if(b.async)for(var d=0,f=c.length;d<f;d++){b.totalFiles+=1;var h=b.language.substring(0,2);if(0==a.length||-1!=m.inArray(h,a))b.totalFiles+=
+1;5<=b.language.length&&(h=b.language.substring(0,5),0==a.length||-1!=m.inArray(h,a))&&(b.totalFiles+=1)}d=0;for(f=c.length;d<f;d++)q(b.path+c[d]+".properties",b),h=b.language.substring(0,2),0!=a.length&&-1==m.inArray(h,a)||q(b.path+c[d]+"_"+h+".properties",b),5<=b.language.length&&(h=b.language.substring(0,5),0!=a.length&&-1==m.inArray(h,a)||q(b.path+c[d]+"_"+h+".properties",b));b.callback&&!b.async&&b.callback()};b.checkAvailableLanguages?m.ajax({url:b.path+"languages.json",async:b.async,cache:!1,
+dataType:"json",success:function(b,c,d){a(b.languages||[])}}):a([])};m.i18n.prop=function(b){var a=m.i18n.map[b];if(null==a)return"["+b+"]";var e;2==arguments.length&&m.isArray(arguments[1])&&(e=arguments[1]);var c;if("string"==typeof a){for(c=0;-1!=(c=a.indexOf("\\",c));)a="t"==a.charAt(c+1)?a.substring(0,c)+"\t"+a.substring(c++ +2):"r"==a.charAt(c+1)?a.substring(0,c)+"\r"+a.substring(c++ +2):"n"==a.charAt(c+1)?a.substring(0,c)+"\n"+a.substring(c++ +2):"f"==a.charAt(c+1)?a.substring(0,c)+"\f"+a.substring(c++ +
+2):"\\"==a.charAt(c+1)?a.substring(0,c)+"\\"+a.substring(c++ +2):a.substring(0,c)+a.substring(c+1);var d=[],f,h;for(c=0;c<a.length;)if("'"==a.charAt(c))if(c==a.length-1)a=a.substring(0,c);else if("'"==a.charAt(c+1))a=a.substring(0,c)+a.substring(++c);else{for(f=c+2;-1!=(f=a.indexOf("'",f));)if(f==a.length-1||"'"!=a.charAt(f+1)){a=a.substring(0,c)+a.substring(c+1,f)+a.substring(f+1);c=f-1;break}else a=a.substring(0,f)+a.substring(++f);-1==f&&(a=a.substring(0,c)+a.substring(c+1))}else"{"==a.charAt(c)?
+(f=a.indexOf("}",c+1),-1==f?c++:(h=parseInt(a.substring(c+1,f)),!isNaN(h)&&0<=h?(c=a.substring(0,c),""!=c&&d.push(c),d.push(h),c=0,a=a.substring(f+1)):c=f+1)):c++;""!=a&&d.push(a);a=d;m.i18n.map[b]=d}if(0==a.length)return"";if(1==a.length&&"string"==typeof a[0])return a[0];d="";for(c=0;c<a.length;c++)d="string"==typeof a[c]?d+a[c]:e&&a[c]<e.length?d+e[a[c]]:!e&&a[c]+1<arguments.length?d+arguments[a[c]+1]:d+("{"+a[c]+"}");return d};m.i18n.normaliseLanguageCode=function(b){if(!b||2>b.length)b=navigator.languages?
+navigator.languages[0]:navigator.language||navigator.userLanguage||"en";b=b.toLowerCase();b=b.replace(/-/,"_");3<b.length&&(b=b.substring(0,3)+b.substring(3).toUpperCase());return b};var n;n||(n=function(b,a,e){if("[object RegExp]"!==Object.prototype.toString.call(a))return"undefined"==typeof n._nativeSplit?b.split(a,e):n._nativeSplit.call(b,a,e);var c=[],d=0,f=(a.ignoreCase?"i":"")+(a.multiline?"m":"")+(a.sticky?"y":"");a=new RegExp(a.source,f+"g");var h,g,k;b+="";n._compliantExecNpcg||(h=new RegExp("^"+
+a.source+"$(?!\\s)",f));if(void 0===e||0>+e)e=Infinity;else if(e=Math.floor(+e),!e)return[];for(;g=a.exec(b);){f=g.index+g[0].length;if(f>d&&(c.push(b.slice(d,g.index)),!n._compliantExecNpcg&&1<g.length&&g[0].replace(h,function(){for(var a=1;a<arguments.length-2;a++)void 0===arguments[a]&&(g[a]=void 0)}),1<g.length&&g.index<b.length&&Array.prototype.push.apply(c,g.slice(1)),k=g[0].length,d=f,c.length>=e))break;a.lastIndex===g.index&&a.lastIndex++}d===b.length?!k&&a.test("")||c.push(""):c.push(b.slice(d));
+return c.length>e?c.slice(0,e):c},n._compliantExecNpcg=void 0===/()??/.exec("")[1],n._nativeSplit=String.prototype.split);String.prototype.split=function(b,a){return n(this,b,a)}})(jQuery);


### PR DESCRIPTION
When loading the _languages.json_ the **dataType** should be set to **json** or the response data has to be parsed before accessing **data.languages**. Right now, it is always the empty array that is passed to **languagesFileLoadedCallback()**.
As a result the plugin will continue to try and load e.g. _app_de_DE.properties_ even though the _languages.json_ specified only _app_de.properties_. A missing _.properties_ file will cause a javascript error.
