### PR TITLE
Fix typo: longFilename -> longFileName

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -90,7 +90,7 @@
           }
         }
       }
-      var defaultFileName, shortFileName, longFilename;
+      var defaultFileName, shortFileName, longFileName;
       for (var k = 0, m = files.length; k < m; k++) {
         // 1. load base (eg, Messages.properties)
         defaultFileName = settings.path + files[k] + '.properties';


### PR DESCRIPTION
Fixes:

1. "ReferenceError: longFileName is not defined" if `settings.language.length < 5`;

2. `longFileName` leaks to the global scope if `settings.language.length >=5 `.