### PR TITLE
Fixes loading of files in encodings that are not UTF-8 (from issue #35)

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -304,6 +304,10 @@
                 async: settings.async,
                 cache: settings.cache,
                 dataType: 'text',
+                contentType: 'Content-type: text/plain; charset=' + settings.encoding,
+                beforeSend: function(jqXHR) {
+                    jqXHR.overrideMimeType('text/html;charset=' + settings.encoding);
+                },
                 success: function (data, status) {
 
                     if (settings.debug) {


### PR DESCRIPTION
This fix is needed to correctly load properties that are not in UTF-8. 

In Java, property file encoding must be ISO-8859... so to be able to use the same files in JavaScript, I need them to load correctly.