### PR TITLE
avoid using non-standard String.prototype.trimRight()

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -383,7 +383,7 @@
                     // process multi-line values
                     while (value.search(/\\$/) != -1) {
                         value = value.substring(0, value.length - 1);
-                        value += lines[++i].trimRight();
+			value += lines[++i].replace(/\s+$/,"");
                     }
                     // Put values with embedded '='s back together
                     for (var s = 2; s < pair.length; s++) {


### PR DESCRIPTION
String.prototype.trimRight() is non-standard (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight) and btw. not supported by IE11.