### PR TITLE
info on how to fix syntax error on Apache Webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ If using Firefox and a Tomcat webapp, you may get a `syntax error` in the Javasc
 </mime-mapping>
 `
 
+If using Firefox and an Apache Webserver the same error can be fixed by adding
+`AddType text/plain .properties`
+to your .htaccess file.
+
 ### Building a minified JavaScript file
 
 1. Install the closure compiler tool:


### PR DESCRIPTION
The error described in #24  and #39 also occurs when using an Apache Webserver. It can be solved by addig an entry to the .htaccess file. I've updated the readme.